### PR TITLE
Fix for /issues/1

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -88,7 +88,10 @@ const SpaRouter = ({ routes, pathName, notFound }) => {
     pathName = pathName.slice(0, -1)
   }
 
-  urlParser = UrlParser(pathName)
+  urlParser = UrlParser(
+    document.location.href,
+    pathName
+  )
 
   if (typeof notFound === 'undefined') {
     notFound = ''


### PR DESCRIPTION
Fix for https://github.com/jorgegorka/svelte-router/issues/1

According to the docs on https://github.com/jorgegorka/url-params-parser, you need both     document.location.href and pathName in the UrlParser.