### PR TITLE
Update utils.js

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -66,7 +66,7 @@ function findLocalisedRoute(pathName, route, language) {
  * @param pathname
  **/
 function getNamedParams(pathName = '') {
-  if (pathName.trim().length === '') return []
+  if (pathName.trim().length === 0) return []
 
   const namedUrlParams = getPathNames(pathName)
   return namedUrlParams.reduce((validParams, param, _index) => {


### PR DESCRIPTION
semantic error TS2367: This condition will always return 'false' since the types 'number' and 'string' have no overlap.