### PR TITLE
Fix broken spa_router imports

### DIFF
--- a/src/components/navigate.svelte
+++ b/src/components/navigate.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount } from 'svelte'
-  import { localisedRoute, navigateTo, routeIsActive } from '../router'
+  import { localisedRoute, navigateTo, routeIsActive } from '../spa_router'
   export let to = '/'
   export let title = ''
   export let styles = ''

--- a/src/components/router.svelte
+++ b/src/components/router.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onMount } from 'svelte'
 
-  import { SpaRouter } from '../router'
+  import { SpaRouter } from '../spa_router'
   import Route from './route.svelte'
   import { activeRoute } from '../store'
 


### PR DESCRIPTION
They broke after src/router.js was moved to src/spa_router.js in commit 686807c2578a.

Fixed #37 .