### PR TITLE
Remove undeclared variable redirectTo in findActiveRoute

### DIFF
--- a/src/spa_router.js
+++ b/src/spa_router.js
@@ -28,7 +28,6 @@ function SpaRouter(routes, currentUrl, options = {}) {
 
   function findActiveRoute() {
     let convert = false
-    redirectTo = ''
 
     if (routerOptions.langConvertTo) {
       routerOptions.lang = routerOptions.langConvertTo


### PR DESCRIPTION
Fixed #39 .

I don't know if removing the `redirectTo` variable might have further implications in the codebase. This definitely makes it work for me, but my project is not using guards right now.