### PR TITLE
User can define a base language

### DIFF
--- a/src/router/finder.js
+++ b/src/router/finder.js
@@ -7,7 +7,7 @@ const { anyEmptyNestedRoutes, pathWithoutQueryParams } = require('../lib/utils')
 
 const NotFoundPage = '/404.html'
 
-function RouterFinder(routes, currentUrl, language, convert) {
+function RouterFinder(routes, currentUrl, language, baseLanguage, convert) { 
   let redirectTo = ''
   let routeNamedParams = {}
   const urlParser = UrlParser(currentUrl)
@@ -98,7 +98,7 @@ function RouterFinder(routes, currentUrl, language, convert) {
       path: routePath,
       routeNamedParams,
       namedPath,
-      language: routeLanguage
+      language: routeLanguage === undefined ? baseLanguage : routeLanguage
     })
     routeNamedParams = routerRoute.namedParams()
 

--- a/src/spa_router.js
+++ b/src/spa_router.js
@@ -34,7 +34,7 @@ function SpaRouter(routes, currentUrl, options = {}) {
       convert = true
     }
 
-    return RouterFinder(routes, currentUrl, routerOptions.lang, convert).findActiveRoute()
+    return RouterFinder(routes, currentUrl, routerOptions.lang, routerOptions.baseLang, convert).findActiveRoute()
   }
 
   /**

--- a/test/spa_router.test.js
+++ b/test/spa_router.test.js
@@ -795,12 +795,17 @@ describe('Router', function() {
     describe('when no language is set', function() {
       describe('a simple route', function() {
         beforeEach(function() {
+          const options = { baseLang: 'en' }
           pathName = 'http://web.app/admin/employees'
-          testRouter = SpaRouter(routes, pathName)
+          testRouter = SpaRouter(routes, pathName, options)
         })
 
         it('should set the correct path', function() {
           expect(testRouter.setActiveRoute().path).to.equal('/admin/employees')
+        })
+
+        it('should return the base language if provided by user', function() {
+          expect(testRouter.setActiveRoute().language).equal('en')
         })
       })
 


### PR DESCRIPTION
```javascript
  const routes = [
    {
      name: "checkout",
      component: Checkout,
      lang: {
        sv: "kassa"
      }
    }
  ];
```

```javascript
const options = { baseLang: 'en' }

<Router {routes} {options} />
```

It would be nice if `currentRoute` consistently returned a language code. If I navigate to /kassa `currentRoute.language` returns `sv`, but /checkout is undefined. Allowing the user to define the base routing language would make it simpler when using something like svelte-intl.