### PR TITLE
Fixed the 404 route, so we can override the path in routes configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Example:
   <TopHeader />
   <section class="section">
     <Route {currentRoute} {params} />
-    <p>Route params are: {currentRoute.namedParams} and {currentRoute.queryParams)
+    <p>Route params are: {currentRoute.namedParams} and {currentRoute.queryParams}</p>
   </section>
   <FooterContent />
 </div>

--- a/src/router/finder.js
+++ b/src/router/finder.js
@@ -110,7 +110,7 @@ function RouterFinder({ routes, currentUrl, routerOptions, convert }) {
     const custom404Page = routes.find((route) => route.name == '404')
     const language = customLanguage || defaultLanguage || ''
     if (custom404Page) {
-      return { ...custom404Page, language, path: '404' }
+      return { path: '404', ...custom404Page, language }
     } else {
       return { name: '404', component: '', path: '404', redirectTo: NotFoundPage }
     }


### PR DESCRIPTION
in the 404 configuration the `path` parameter was not taken into account when defined by user. Now it's used instead of the default one.

+Fix in README