### PR TITLE
Fixed hash tags in achor

### DIFF
--- a/src/router/current.js
+++ b/src/router/current.js
@@ -8,6 +8,9 @@ function RouterCurrent(trackPage) {
 
   function setActive(newRoute) {
     activeRoute = newRoute.path
+    if (newRoute.hash) {
+      location.hash = newRoute.hash;
+    }
     pushActiveRoute(newRoute)
   }
 

--- a/src/router/route.js
+++ b/src/router/route.js
@@ -11,6 +11,7 @@ function RouterRoute({ routeInfo, path, routeNamedParams, urlParser, namedPath, 
     return {
       name: path,
       component: routeInfo.component,
+      hash: urlParser.hash,
       layout: routeInfo.layout,
       queryParams: urlParser.queryParams,
       namedParams: namedParams(),

--- a/src/spa_router.js
+++ b/src/spa_router.js
@@ -115,7 +115,7 @@ if (typeof window !== 'undefined') {
       if (event.target.hash) {
         navigatePathname += event.target.hash
       }
-      const destinationUrl = event.target.pathname + event.target.search
+      const destinationUrl = navigatePathname + event.target.search
       if (event.target.target === '_blank') {
         window.open(destinationUrl, 'newTab')
       } else {


### PR DESCRIPTION
This is a fix for https://github.com/jorgegorka/svelte-router/issues/80 together with my other PR in url-params-parser: https://github.com/jorgegorka/url-params-parser/pull/5

Note that the url-params-parser needs to be merged first to be able to provide the hash.