### PR TITLE
feat: support lazy load component

### DIFF
--- a/src/components/route.svelte
+++ b/src/components/route.svelte
@@ -5,6 +5,10 @@
 
 {#if currentRoute.layout}
   <svelte:component this={currentRoute.layout} currentRoute={{ ...currentRoute, layout: '' }} {params} />
+{:else if currentRoute.asyncComponent}
+  {#await currentRoute.asyncComponent() then c}
+    <svelte:component this={c.default} currentRoute={{ ...currentRoute, asyncComponent: '' }} {params} />
+  {/await}
 {:else if currentRoute.component}
   <svelte:component this={currentRoute.component} currentRoute={{ ...currentRoute, component: '' }} {params} />
 {:else if currentRoute.childRoute}

--- a/types/components/route.d.ts
+++ b/types/components/route.d.ts
@@ -3,11 +3,11 @@ import type { SvelteComponent, SvelteComponentTyped } from 'svelte/internal';
 export type CurrentRoute = {
   name: string;
   component: SvelteComponent;
-  layout: SvelteComponent;
-  queryParams: Record<string, any>;
-  namedParams: Record<string, any>;
-  childRoute: CurrentRoute;
-  language: string;
+  layout?: SvelteComponent;
+  queryParams?: Record<string, any>;
+  namedParams?: Record<string, any>;
+  childRoute?: CurrentRoute;
+  language?: string;
 };
 
 export interface RouteProps {

--- a/types/components/route.d.ts
+++ b/types/components/route.d.ts
@@ -1,8 +1,11 @@
 import type { SvelteComponent, SvelteComponentTyped } from 'svelte/internal';
 
+export type AsyncSvelteComponent = () => Promise<{ default: typeof SvelteComponent }>;
+
 export type CurrentRoute = {
   name: string;
-  component: SvelteComponent;
+  component?: SvelteComponent;
+  asyncComponent?: AsyncSvelteComponent;
   layout?: SvelteComponent;
   queryParams?: Record<string, any>;
   namedParams?: Record<string, any>;


### PR DESCRIPTION
The advantage of using lazy load is that you can enable code-splitting, which will drastically reduce the bundle size you send to the user.