### PR TITLE
chore: Avoid modifying original route name

### DIFF
--- a/src/router/finder.js
+++ b/src/router/finder.js
@@ -45,10 +45,9 @@ function RouterFinder({ routes, currentUrl, routerOptions, convert }) {
 
     routes.forEach(function (route) {
       routerPath.updatedPath(route);
-      if (route.name !== '/') {
-        route.name = removeSlash(route.name);
-      }
-      if (matchRoute(routerPath, route.name)) {
+      const routeName = route.name === '/' ? route.name : removeSlash(route.name);
+      
+      if (matchRoute(routerPath, routeName)) {
         let routePath = routerPath.routePath();
         redirectTo = RouterRedirect(route, redirectTo).path();
 


### PR DESCRIPTION
Current behaviour removes name slash from route objects list defined on application initialization. However, it would be more wise to keep route array of objects intact, in case developers want to use route property data for more things.