### PR TITLE
fix: An alternate fix for broken paths with named params that started with "/".

### DIFF
--- a/src/router/finder.js
+++ b/src/router/finder.js
@@ -2,7 +2,7 @@ import { UrlParser } from './url_parser';
 import { RouterRedirect } from './redirect';
 import { RouterRoute } from './route';
 import { RouterPath } from './path';
-import { anyEmptyNestedRoutes, pathWithoutQueryParams, removeSlash, startsWithNamedParam } from '../lib/utils';
+import { anyEmptyNestedRoutes, pathWithoutQueryParams, startsWithNamedParam } from '../lib/utils';
 
 const NotFoundPage = '/404.html';
 
@@ -45,9 +45,6 @@ function RouterFinder({ routes, currentUrl, routerOptions, convert }) {
 
     routes.forEach(function (route) {
       routerPath.updatedPath(route);
-      if (route.name !== '/') {
-        route.name = removeSlash(route.name);
-      }
 
       if (matchRoute(routerPath, route.name)) {
         let routePath = routerPath.routePath();

--- a/src/router/path.js
+++ b/src/router/path.js
@@ -33,8 +33,8 @@ function RouterPath({ basePath, basePathName, pathNames, convert, currentLanguag
 
   function namedPath() {
     let localisedPath = localisedPathName();
-    if (localisedPath && !localisedPath.startsWith("/")) {
-      localisedPath = "/" + localisedPath;
+    if (localisedPath && !localisedPath.startsWith('/')) {
+      localisedPath = '/' + localisedPath;
     }
 
     return basePath ? `${basePath}${localisedPath}` : localisedPath;

--- a/src/router/path.js
+++ b/src/router/path.js
@@ -3,7 +3,6 @@ import {
   nameToPath,
   updateRoutePath,
   removeExtraPaths,
-  removeSlash,
   routeNameLocalised
 } from '../lib/utils';
 
@@ -33,9 +32,12 @@ function RouterPath({ basePath, basePathName, pathNames, convert, currentLanguag
   }
 
   function namedPath() {
-    const localisedPath = localisedPathName();
+    let localisedPath = localisedPathName();
+    if (localisedPath && !localisedPath.startsWith("/")) {
+      localisedPath = "/" + localisedPath;
+    }
 
-    return basePath ? `${basePath}/${localisedPath}` : localisedPath;
+    return basePath ? `${basePath}${localisedPath}` : localisedPath;
   }
 
   function routePath() {

--- a/test/spa_router.test.js
+++ b/test/spa_router.test.js
@@ -456,11 +456,11 @@ describe('Router', function () {
         expect(showEmployeeRoute.component).to.equal('ShowEmployee')
       })
 
-      it('should set named params', function () {
+      it('should set named params id', function () {
         expect(showEmployeeRoute.namedParams.id).to.equal('12')
       })
 
-      it('should set named params', function () {
+      it('should set named params full-name', function () {
         expect(showEmployeeRoute.namedParams['full-name']).to.equal('Danny-filth')
       })
     })


### PR DESCRIPTION
This is an alternate attempt to fix routes with named params that broke when they started with "/".
The concept of it is to keep route names intact without removing slashes which results in modifying given array of route objects.

All tests seem to pass, too.
Please let me know what you think about this, maybe we can improve it more or leave it as is.