### PR TITLE
fix: sitePrefix replace fails if at /

### DIFF
--- a/src/router/finder.js
+++ b/src/router/finder.js
@@ -108,7 +108,8 @@ function RouterFinder({ routes, currentUrl, routerOptions, convert }) {
 
   function parseCurrentUrl(currentUrl, sitePrefix) {
     if (sitePrefix && sitePrefix.trim().length > 0) {
-      const noPrefixUrl = currentUrl.replace(sitePrefix + '/', '');
+      const replacePattern = currentUrl.endsWith(sitePrefix) ? sitePrefix : sitePrefix + "/";
+      const noPrefixUrl = currentUrl.replace(replacePattern, '');
       return UrlParser(noPrefixUrl);
     } else {
       return UrlParser(currentUrl);

--- a/test/spa_router.test.js
+++ b/test/spa_router.test.js
@@ -1863,6 +1863,21 @@ describe('With site prefix', function () {
     },
   ]
 
+  describe('root route', function () {
+    beforeEach(function () {
+      currentUrl = 'http://web.app/company/'
+      activeRoute = SpaRouter(routes, currentUrl, { prefix: 'company' }).setActiveRoute()
+    })
+
+    it('should set path to root path', function () {
+      expect(activeRoute.path).to.equal('/company/')
+    })
+
+    it('should set component name', function () {
+      expect(activeRoute.component).to.equal('PublicLayout')
+    })
+  })
+
   describe('about us route', function () {
     beforeEach(function () {
       currentUrl = 'http://web.app/company/about-us'


### PR DESCRIPTION
If sitePrefix is defined and the website is hosted under a subdomain, the path for index at "<sitePrefix>/" will fail and set the path as "undefined". 

The cause is that the trailing "/" is removed in [spa_router.js:26](https://github.com/jorgegorka/svelte-router/blob/master/src/spa_router.js#L26) but is appended again in [finder.js:111](https://github.com/jorgegorka/svelte-router/blob/master/src/router/finder.js#L111). This causes the replace to fail.