### PR TITLE
Handle and preserve multiple values for a field

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -121,7 +121,13 @@ const pathWithQueryParams = (currentRoute) => {
   let queryParams = [];
   if (currentRoute.queryParams) {
     for (let [key, value] of Object.entries(currentRoute.queryParams)) {
-      queryParams.push(`${key}=${value}`);
+      if (Array.isArray(value)) {
+        for (let subvalue of value) {
+          queryParams.push(`${key}=${subvalue}`)
+        }
+      } else {
+        queryParams.push(`${key}=${value}`);
+      }
     }
   }
 

--- a/src/router/url_parser.js
+++ b/src/router/url_parser.js
@@ -120,7 +120,11 @@ const UrlParser = (urlString, namedUrl = '') => {
   function queryParams() {
     const params = {};
     urlBase.searchParams.forEach((value, key) => {
-      params[key] = value;
+      if (params.hasOwnProperty(key)) {
+        params[key] = [].concat(params[key]).concat(value)
+      } else {
+        params[key] = value;
+      }
     });
 
     return params;

--- a/test/spa_router.test.js
+++ b/test/spa_router.test.js
@@ -247,10 +247,27 @@ describe('Router', function() {
         expect(testRouter.queryParams['fullView']).to.equal('true')
       })
     })
+
+    describe('Multiple values for same field', function () {
+      beforeEach(function () {
+        pathName = 'http://web.app/login?climate=change&consequence=sea-rising&consequence=temperature-rising&consequence=extreme-weather'
+        testRouter = SpaRouter(routes, pathName).setActiveRoute()
+      })
+
+      it('should update queryParams', function () {
+        expect(testRouter.queryParams.climate).to.equal('change')
+      })
+      it('should update queryParams with a list', function () {
+        expect(testRouter.queryParams['consequence']).to.have.same.members(['sea-rising', 'temperature-rising', 'extreme-weather'])
+      })
+      it('should keep multiple values in url', function () {
+        expect(global.window.history.state.page).to.equal("/login?climate=change&consequence=sea-rising&consequence=temperature-rising&consequence=extreme-weather")
+      })
+    })
   })
 
-  describe('When there are valid routes no nesting with named params', function() {
-    beforeEach(function() {
+  describe('When there are valid routes no nesting with named params', function () {
+    beforeEach(function () {
       routes = [
         {
           name: '/',


### PR DESCRIPTION
URLs like http://localhost/?field=value1&field=value2 are automatically converted into http://localhost/?field=value2, i.e. losing all values except the last.

This pull request will automatically parse such values into an array, and re-format into multiple "key=value" pairs when transforming back into a query string.