### PR TITLE
Fix svelte resolve warning in when using Vite and vite-plugin-svelte for compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
   "module": "lib/esm/index.js",
   "svelte": "src/index.js",
   "exports": {
-     ".": {
-       "svelte": "./src/index.js"
-     }
+    ".": {
+      "svelte": "./src/index.js"
+    },
+    "./src/store.js": {
+      "svelte": "./src/store.js"
+    }
   },
   "unpkg": "lib/index.min.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "browser": "lib/index.js",
   "module": "lib/esm/index.js",
   "svelte": "src/index.js",
+  "exports": {
+     ".": {
+       "svelte": "./src/index.js"
+     }
+  },
   "unpkg": "lib/index.min.js",
   "types": "types/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "main": "lib/cjs/index.js",
   "browser": "lib/index.js",
   "module": "lib/esm/index.js",
-  "svelte": "src/index.js",
   "exports": {
     ".": {
       "svelte": "./src/index.js"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     ".": {
       "svelte": "./src/index.js"
     },
+    "./src/spa_router.js": {
+      "svelte": "./src/spa_router.js"
+    },
     "./src/store.js": {
       "svelte": "./src/store.js"
     }


### PR DESCRIPTION
Hello

This is my first attempt at OpenSource contribution.
This PR aims to fix a warning of deprecation/future build issues, when compiling SvelteJS apps using this package in Vite and with [vite-plugin-svelte](https://github.com/sveltejs/vite-plugin-svelte): 

```
[vite-plugin-svelte] WARNING: The following packages use a svelte resolve configuration in package.json that has conflicting results and is going to cause problems future.

svelte-router-spa@6.0.3

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#conflicts-in-svelte-resolve for details.
```

I've raised this issue a couple of months ago, and wanted to try to fix it myself: https://github.com/jorgegorka/svelte-router/issues/145

Approach:
- I have followed the suggestion from the [SvelteJS documentation](https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#conflicts-in-svelte-resolve) to add support for the exports portion of package.json, while maintaining the existing exports from the src directory. I also referred to [this section](https://nodejs.org/api/packages.html#packages_package_entry_points) of the NodeJS documentation for entrypoints for multiple submodules.
- I have tested this fork in my own app to ensure that it removes the warning.

**BE AWARE:** I'm unsure of whether this might remove support for other Svelte compilers (non-Vite), since it is necessary to remove the "svelte" key from package.json for the warning to go away. I was unsure of how to test / proceed with this concern. Feedback greatly appreciated.

Thank you for a great router - I hope this contribution is easy to include, else let me know if some action is needed on my part.