### PR TITLE
change peer dependencies to support svelte 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url-params-parser": "^1.0.3"
   },
   "peerDependencies": {
-    "svelte": "^3.36.0"
+    "svelte": "^4.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
only change peer dependencies to support svelte 4. haven't fully tested it tho.